### PR TITLE
Add tickets menu item

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -31,6 +31,8 @@ WAFER_MENUS += (
      "items": []},
     {"name": "venue", "label": _("Venue"),
      "url": reverse_lazy("wafer_page", args=("venue",))},
+    {"menu": "tickets", "label": _("Tickets"),
+     "items": []},
     {"menu": "sponsors", "label": _("Sponsors"),
      "items": []},
     {"menu": "talks", "label": _("Talks"),


### PR DESCRIPTION
New Ticket menu to contain "Ticket prices" and "Buy tickets" pages in order to make them easier to find (particularly when not at home page.) 
I believe that it's a better place than the About page and that it's among the most important menu items on a conference website and that the menu won't be too cluttered.